### PR TITLE
fix register numerator

### DIFF
--- a/analysis/dict_hyp_variables.py
+++ b/analysis/dict_hyp_variables.py
@@ -64,8 +64,10 @@ hyp_reg_variables = dict(
         # of hypertension which has not been subsequently resolved.
         (hypertension AND (NOT hypertension_resolved)) OR
 
-        ((hypertension AND hypertension_resolved) AND
-        (hypertension_resolved_date <= hypertension_date))
+        (
+            (hypertension AND hypertension_resolved) AND
+            (hypertension_resolved_date <= hypertension_date)
+        )
         """
     ),
 )


### PR DESCRIPTION
problem: currently our numerator is much larger than we would expect. we think this is because:

`(hypertension_resolved_date <= hypertension_date)`

in the hypertension_register variable could return `True` for patients that dont have either: hypertension diagnosis or hypertension resolved code. this would mean that I'm currently including everyone who never had a hypertension diagnosis or resolved code and might result in the large numerator I get in the results.

adding a new check ensures that the date comparison is only applied to patients where we have both hypertension AND hypertension_resolved: 

```
(hypertension AND hypertension_resolved) AND
(hypertension_resolved_date <= hypertension_date) 
```