### PR TITLE
Extend study date range

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,12 +1,12 @@
 # Study start date
 # Note: This should match the start dates in project.yaml
 # In QOF also: Payment Period Start Date (PPSD)
-start_date = "2019-03-01"
+start_date = "2019-04-01"
 
 # Study end date
 # Note: This should match the end dates in project.yaml
 # In QOF also: Payment Period End Date (PPED)
-end_date = "2022-10-01"
+end_date = "2023-03-31"
 
 # Demographic variables by which measures are broken down
 demographic_breakdowns = [

--- a/project.yaml
+++ b/project.yaml
@@ -22,7 +22,7 @@ actions:
     run: > 
       cohortextractor:latest generate_cohort 
       --study-definition study_definition_hyp001 
-      --index-date-range "2019-03-01 to 2022-10-01 by month" 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output/indicators
       --output-format=feather
     outputs:
@@ -34,7 +34,7 @@ actions:
     run: > 
       cohortextractor:latest generate_cohort 
       --study-definition study_definition_hyp003 
-      --index-date-range "2019-03-01 to 2022-10-01 by month" 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output/indicators  
       --output-format=feather
     outputs:
@@ -46,7 +46,7 @@ actions:
     run: > 
       cohortextractor:latest generate_cohort 
       --study-definition study_definition_hyp007 
-      --index-date-range "2019-03-01 to 2022-10-01 by month" 
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
       --output-dir=output/indicators  
       --output-format=feather
     outputs:


### PR DESCRIPTION
This adds 4 complete NHS financial years:
- 1st April 2019 - 31st March 2020
- 1st April 2020 - 31st March 2021
- 1st April 2021 - 31st March 2022
- 1st April 2022 - 31st March 2023