### PR TITLE
Add BP002 indicator with 1 year lookback period

### DIFF
--- a/analysis/dict_bp_variables.py
+++ b/analysis/dict_bp_variables.py
@@ -1,0 +1,140 @@
+# Define common variables needed across indicators here
+# See https://docs.opensafely.org/study-def-tricks/
+
+import pandas as pd
+from config import start_date, end_date
+from cohortextractor import patients
+from codelists import (
+    bp_codes,
+    bp_dec_codes,
+)
+
+# Define dictionary of variables needed for blood pressure indicator BP002
+# with 1 year lookback:
+bp002_variables_1y_lookback = dict(
+    # Denominator Rule Number 1
+    # Description: Reject patients from the specified population who are
+    # aged less than 45 years old.
+    bp002_denominator_r1=patients.satisfying(
+        """
+        age >= 45
+        """
+    ),
+    # Denominator Rule Number 2
+    # NOTE: This is same as Numerator Rule Number 1
+    # Description: Select patients passed to this rule who had their blood
+    # pressure recorded in the *1 year* period leading up to and including
+    # the payment period end date.
+    bp002_denominator_r2=patients.satisfying(
+        """
+        bp_rec_1y
+        """,
+        bp_rec_1y=patients.with_these_clinical_events(
+            codelist=bp_codes,
+            between=[
+                "first_day_of_month(index_date) - 1 year",
+                "last_day_of_month(index_date)",
+            ],
+            returning="binary_flag",
+            return_expectations={"incidence": 0.5},
+        ),
+    ),
+    # Denominator Rule Number 3
+    # Description: Reject patients passed to this rule chose not to have
+    # their blood pressure recorded in the *1 year* period leading up to and
+    # including the payment period end date.
+    bp002_denominator_r3=patients.satisfying(
+        """
+        NOT bp_dec_1y
+        """,
+        bp_dec_1y=patients.with_these_clinical_events(
+            between=[
+                "first_day_of_month(index_date) - 1 year",
+                "last_day_of_month(index_date)",
+            ],
+            codelist=bp_dec_codes,
+            returning="binary_flag",
+        ),
+    ),
+    # Define exclusion variable for denominator rule 3
+    # to be used as numerator in measures
+    bp002_excl_denominator_r3=patients.satisfying(
+        """
+        bp_dec_1y
+        """
+    ),
+    # Denominator Rule Number 4
+    # Description: Reject patients passed to this rule who registered with
+    # the GP practice in the 3 month period leading up to and including
+    # the payment period end date.
+    bp002_denominator_r4=patients.satisfying(
+        """
+        reg_dat_3m
+        """,
+        # NOTE: This variable selects patients that were registered with one
+        # practice in the last 3 months. Therefore, this variable (reg_dat_3m)
+        # specifies the patients that need to be selected for in the
+        # denominator.
+        reg_dat_3m=patients.registered_with_one_practice_between(
+            start_date="index_date - 3 months",
+            end_date="index_date",
+            return_expectations={"incidence": 0.1},
+        ),
+    ),
+    # Define exclusion variable for denominator rule 4
+    # to be used as numerator in measures
+    bp002_excl_denominator_r4=patients.satisfying(
+        """
+        NOT reg_dat_3m
+        """
+    ),
+    # Add flowchart counts for each select / reject rule
+    # NOTE: Some of these variables are coded as "select" variables
+    # and not "reject" as specified in the business rules
+    bp002_denominator_r1_reject=patients.satisfying(
+        """
+        bp002_denominator_r1
+        """
+    ),
+    bp002_denominator_r2_select=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        bp002_denominator_r2
+        """
+    ),
+    bp002_denominator_r3_reject=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        (NOT bp002_denominator_r2) AND
+        bp_dec_1y
+        """
+    ),
+    bp002_denominator_r4_reject=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+        (NOT bp002_denominator_r2) AND
+        bp002_denominator_r3 AND
+        (NOT reg_dat_3m)
+        """
+    ),
+    bp002_denominator=patients.satisfying(
+        """
+        bp002_denominator_r1 AND
+            (bp002_denominator_r2 OR
+                (bp002_denominator_r3 AND
+                 bp002_denominator_r4)
+            )
+        """
+    ),
+    bp002_numerator=patients.satisfying(
+        """
+        # Numerator Rule Number 1
+        # NOTE: This is same as Denominator Rule Number 2
+        # Description: Select patients from the denominator who had their
+        # blood pressure recorded in the 5 year period leading up to and
+        # including the payment period end date. Reject the remaining patients.
+        bp002_denominator AND
+        bp002_denominator_r2
+        """
+    ),
+)

--- a/analysis/join_deciles.R
+++ b/analysis/join_deciles.R
@@ -21,7 +21,10 @@ df_hyp003_deciles <- read_csv("output/indicators/joined/deciles_table_hyp003_ach
 df_hyp007_deciles <- read_csv("output/indicators/joined/deciles_table_hyp007_achievem_practice_breakdown_rate.csv") %>%
   mutate(indicator = "hyp007")
 
-df_hyp_deciles_practice <- bind_rows(df_hyp001_deciles, df_hyp003_deciles, df_hyp007_deciles) %>%
+df_bp002_1y_hypreg_deciles <- read_csv("output/indicators/joined/deciles_table_bp002_1y_achievem_hypreg_practice_breakdown_rate.csv") %>%
+  mutate(indicator = "bp002_1y_hypreg")
+
+df_hyp_deciles_practice <- bind_rows(df_hyp001_deciles, df_hyp003_deciles, df_hyp007_deciles, df_bp002_1y_hypreg_deciles) %>%
   relocate(indicator)
 
 fs::dir_create(here::here("output", "indicators", "joined", "deciles"))

--- a/analysis/study_definition_bp002_1y_lookback.py
+++ b/analysis/study_definition_bp002_1y_lookback.py
@@ -1,0 +1,72 @@
+from cohortextractor import StudyDefinition, patients, Measure
+
+import json
+import pandas as pd
+
+# Import dates and codelists
+from config import (
+    start_date,
+    end_date,
+    demographic_breakdowns,
+)
+
+from codelists import bp_codes, bp_dec_codes
+
+# Import shared variable dictionaries
+from dict_bp_variables import bp002_variables_1y_lookback
+from dict_demo_variables import demographic_variables
+from dict_hyp_variables import hyp_reg_variables
+
+study = StudyDefinition(
+    index_date=start_date,
+    default_expectations={
+        "date": {"earliest": start_date, "latest": end_date},
+        "rate": "uniform",
+        "incidence": 0.5,
+    },
+    population=patients.satisfying(
+        """
+        # Define general population parameters
+        gms_reg_status AND
+        (NOT died) AND
+        (sex = 'F' OR sex = 'M') AND
+        (age_band != 'missing') AND
+        # Set population to be hypertension register
+        hyp_reg
+        """,
+    ),
+    # Include blood pressure and demographic variable dictionaries
+    **demographic_variables,
+    # Include hypertension variables for register
+    **hyp_reg_variables,
+    **bp002_variables_1y_lookback,
+)
+
+# Create blood pressure achievement measures
+measures = [
+    Measure(
+        id="bp002_1y_achievem_hypreg_population_rate",
+        numerator="bp002_numerator",
+        denominator="population",
+        group_by=["population"],
+        small_number_suppression=True,
+    ),
+    Measure(
+        id="bp002_1y_achievem_hypreg_practice_breakdown_rate",
+        numerator="bp002_numerator",
+        denominator="population",
+        group_by=["practice"],
+        small_number_suppression=True,
+    ),
+]
+
+# Create demographic breakdowns for blood pressure indicator BP002 measures
+for breakdown in demographic_breakdowns:
+    m = Measure(
+        id=f"bp002_1y_achievem_hypreg_{breakdown}_breakdown_rate",
+        numerator="bp002_numerator",
+        denominator="population",
+        group_by=[breakdown],
+        small_number_suppression=True,
+    )
+    measures.append(m)

--- a/project.yaml
+++ b/project.yaml
@@ -53,16 +53,27 @@ actions:
       highly_sensitive:
         cohort: output/indicators/input_hyp007_*.feather
 
+  generate_study_population_bp002_1y_lookback:
+    run: > 
+      cohortextractor:latest generate_cohort 
+      --study-definition study_definition_bp002_1y_lookback
+      --index-date-range "2019-04-01 to 2023-03-31 by month" 
+      --output-dir=output/indicators
+      --output-format=feather
+    outputs:
+      highly_sensitive:
+        cohort: output/indicators/input_bp002_1y*.feather
+  
   join_ethnicity:
     run: >
       cohort-joiner:v0.0.27
-        --lhs output/indicators/input_hyp*.feather
+        --lhs output/indicators/input_*.feather
         --rhs output/indicators/input_ethnicity.feather
         --output-dir output/indicators/joined
-    needs: [generate_study_population_ethnicity, generate_study_population_hyp001, generate_study_population_hyp003, generate_study_population_hyp007]
+    needs: [generate_study_population_ethnicity, generate_study_population_hyp001, generate_study_population_hyp003, generate_study_population_hyp007, generate_study_population_bp002_1y_lookback]
     outputs:
       highly_sensitive:
-        cohort: output/indicators/joined/input_hyp*.feather
+        cohort: output/indicators/joined/input_*.feather
 
   # Measures
   # Generate measures for indicator HYP001 by month
@@ -98,6 +109,16 @@ actions:
        moderately_sensitive:
          measure_csv: output/indicators/joined/measure_hyp007_*_rate.csv
 
+  generate_measures_bp002_1y_lookback:
+     run: >
+       cohortextractor:latest generate_measures 
+       --study-definition study_definition_bp002_1y_lookback 
+       --output-dir=output/indicators/joined
+     needs: [join_ethnicity]
+     outputs:
+       moderately_sensitive:
+         measure_csv: output/indicators/joined/measure_bp002_1y*_rate.csv
+
   generate_deciles:
     run: >
       deciles-charts:v0.0.21
@@ -109,7 +130,7 @@ actions:
         output: true
       charts:
         output: true
-    needs: [generate_measures_hyp001, generate_measures_hyp003, generate_measures_hyp007]
+    needs: [generate_measures_hyp001, generate_measures_hyp003, generate_measures_hyp007, generate_measures_bp002_1y_lookback]
     outputs:
       moderately_sensitive:
         deciles_charts: output/indicators/joined/deciles_chart_*_*_practice_breakdown_rate.png
@@ -128,10 +149,10 @@ actions:
   # # Join all measure files for each indicator
   join_measures:
     run: r:latest analysis/join_measures.R
-    needs: [generate_measures_hyp001, generate_measures_hyp003, generate_measures_hyp007]
+    needs: [generate_measures_hyp001, generate_measures_hyp003, generate_measures_hyp007, generate_measures_bp002_1y_lookback]
     outputs:
       moderately_sensitive:
-        measure_csv: output/indicators/joined/measures/measures_hyp*.csv
+        measure_csv: output/indicators/joined/measures/measures_*.csv
 
   # # Join all deciles (by practice) files for each indicator
   join_deciles:


### PR DESCRIPTION
This PR applies the BP002 indicator with a 1y lookback period to the hypertension register population.

1. First, the codelists and study definition get added together with the measures that use the population (in this cases the hypertension register) as the denominator.
2. All subsequent actions in the pipeline are updated. This includes the following downstream actions: (1) generate deciles, (2) join measures, and (3) join deciles.